### PR TITLE
Fix dropdown overflow and action menu UI

### DIFF
--- a/application/modules/approval_expense_report_project/views/index.php
+++ b/application/modules/approval_expense_report_project/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Approval_expense_Report_Project.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -216,5 +243,32 @@ $ENABLE_DELETE  = has_permission('Approval_expense_Report_Project.Delete');
             scrollX: true
         });
     }
+</script>
+<script type="text/javascript">
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.dropdown-menu').hide();
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+        var offset = $btn.offset();
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + $btn.outerHeight() - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - $btn.outerWidth()) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>

--- a/application/modules/approval_kasbon_overbudget/views/index.php
+++ b/application/modules/approval_kasbon_overbudget/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Approval_Kasbon_Overbudget.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -342,5 +369,32 @@ $ENABLE_DELETE  = has_permission('Approval_Kasbon_Overbudget.Delete');
             scrollX: true
         });
     }
+</script>
+<script type="text/javascript">
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.dropdown-menu').hide();
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+        var offset = $btn.offset();
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + $btn.outerHeight() - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - $btn.outerWidth()) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>

--- a/application/modules/approval_kasbon_project/views/index.php
+++ b/application/modules/approval_kasbon_project/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Approval_Kasbon_Project.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -179,5 +206,32 @@ $ENABLE_DELETE  = has_permission('Approval_Kasbon_Project.Delete');
             scrollX: true
         });
     }
+</script>
+<script type="text/javascript">
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.dropdown-menu').hide();
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+        var offset = $btn.offset();
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + $btn.outerHeight() - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - $btn.outerWidth()) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>

--- a/application/modules/approval_penawaran/controllers/Approval_penawaran.php
+++ b/application/modules/approval_penawaran/controllers/Approval_penawaran.php
@@ -240,19 +240,19 @@ class Approval_penawaran extends Admin_Controller
         $length = $this->input->post('length');
         $search = $this->input->post('search');
 
-        $this->db->select('a.*, c.name as nama_marketing');
+        $dbhr = $this->load->database('dbhr', true);
+
+        $this->db->select('a.*, b.nm_customer, d.nm_paket');
         $this->db->from('kons_tr_penawaran a');
         $this->db->join('customer b', 'b.id_customer = a.id_customer', 'left');
-        $this->db->join(DBHR . '.employees c', 'c.id = a.id_marketing', 'left');
         $this->db->join('kons_master_konsultasi_header d', 'd.id_konsultasi_h = a.id_paket', 'left');
         $this->db->where('a.deleted_by', null);
         $this->db->where('a.sts_quot', 1);
         $this->db->where('a.sts_deal', null);
-        if (!empty($search)) {
+        if (!empty($search) && !empty($search['value'])) {
             $this->db->group_start();
             $this->db->like('a.tgl_quotation', $search['value'], 'both');
             $this->db->or_like('a.id_quotation', $search['value'], 'both');
-            $this->db->or_like('c.name', $search['value'], 'both');
             $this->db->or_like('d.nm_paket', $search['value'], 'both');
             $this->db->or_like('b.nm_customer', $search['value'], 'both');
             $this->db->or_like('a.grand_total', str_replace(',', '', $search['value']), 'both');
@@ -319,60 +319,46 @@ class Approval_penawaran extends Admin_Controller
                     aria-expanded="false">
                     <i class="fa fa-cogs"></i> <span class="caret"></span>
                 </button>
-                <div class="dropdown-menu dropdown-menu-right">
+                <ul class="dropdown-menu dropdown-menu-right" style="min-width: 150px; padding: 5px 0;">
             ';
 
             if ($this->viewPermission) {
                 $option .= '
-                    <div class="col-12" style="margin-left: 0.5rem">
-                        <a href="' . base_url('approval_penawaran/view_penawaran/' . urlencode(str_replace('/', '|', $item->id_quotation))) . '" class="btn btn-sm btn-info" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-file"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_penawaran/view_penawaran/' . urlencode(str_replace('/', '|', $item->id_quotation))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-file text-info"></i> View
                         </a>
-                        <span style="font-weight: 500"> View </span>
-                    </div>
+                    </li>
                 ';
             }
 
             if ($this->managePermission) {
                 $option .= '
-                    <div class="col-12" style="margin-top: 0.5rem; margin-left: 0.5rem">
-                        <a href="' . base_url('approval_penawaran/approval/' . urlencode(str_replace('/', '|', $item->id_quotation))) . '" class="btn btn-sm btn-success" style="color: #000000" >
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-edit"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_penawaran/approval/' . urlencode(str_replace('/', '|', $item->id_quotation))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-check text-success"></i> Approval
                         </a>
-                        <span style="font-weight: 500"> Approve </span>
-                    </div>
+                    </li>
                 ';
             }
 
-            $option .= '</div>';
+            $option .= '</ul>';
 
+            // Get marketing name from HR database using separate connection
+            $nm_marketing = '';
+            if (!empty($item->id_marketing)) {
+                $get_marketing = $dbhr->get_where('employees', ['id' => $item->id_marketing])->row();
+                $nm_marketing = (!empty($get_marketing)) ? $get_marketing->name : '';
+            }
 
-            $get_marketing = $this->db->get_where('employee', ['id' => $item->id_marketing])->row();
-            $nm_marketing = (!empty($get_marketing)) ? $get_marketing->nm_karyawan : '';
-
-            $this->db->select('a.*');
-            $this->db->from('kons_master_konsultasi_header a');
-            $this->db->where('a.id_konsultasi_h', $item->id_paket);
-            $get_package = $this->db->get()->row();
-
-            $nm_paket = (!empty($get_package)) ? $get_package->nm_paket : '';
-
-            $get_customers = $this->db->get_where('customer', ['id_customer' => $item->id_customer])->row();
-            $nm_customer = (!empty($get_customers)) ? $get_customers->nm_customer : '';
+            $nm_paket = (!empty($item->nm_paket)) ? $item->nm_paket : '';
+            $nm_customer = (!empty($item->nm_customer)) ? $item->nm_customer : '';
 
             $hasil[] = [
                 'no' => $no,
                 'id_quotation' => $item->id_quotation,
                 'tgl_quotation' => $item->tgl_quotation,
-                'nm_marketing' => ucfirst($item->nama_marketing),
+                'nm_marketing' => ucfirst($nm_marketing),
                 'nm_paket' => $nm_paket,
                 'nm_customer' => $nm_customer,
                 'grand_total' => number_format($item->grand_total),

--- a/application/modules/approval_penawaran/views/index.php
+++ b/application/modules/approval_penawaran/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Penawaran.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -259,5 +286,44 @@ $ENABLE_DELETE  = has_permission('Penawaran.Delete');
             scrollX: true
         });
     }
+</script>
+<script type="text/javascript">
+    // Fix dropdown terpotong di dalam DataTables scrollX
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Tutup semua dropdown yang sedang terbuka
+        $('.dropdown-menu').removeClass('show-dropdown');
+        $('.dropdown-menu').hide();
+
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+
+        var offset = $btn.offset();
+        var btnHeight = $btn.outerHeight();
+        var btnWidth = $btn.outerWidth();
+
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + btnHeight - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - btnWidth) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+
+    // Tutup dropdown saat klik di luar
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>

--- a/application/modules/approval_project_budgeting/views/index.php
+++ b/application/modules/approval_project_budgeting/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Approval_Project_Budgeting.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -160,5 +187,32 @@ $ENABLE_DELETE  = has_permission('Approval_Project_Budgeting.Delete');
             scrollX: true
         });
     }
+</script>
+<script type="text/javascript">
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.dropdown-menu').hide();
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+        var offset = $btn.offset();
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + $btn.outerHeight() - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - $btn.outerWidth()) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>

--- a/application/modules/approval_spk_direktur/controllers/Approval_spk_direktur.php
+++ b/application/modules/approval_spk_direktur/controllers/Approval_spk_direktur.php
@@ -510,21 +510,16 @@ class Approval_spk_direktur extends Admin_Controller
                     aria-expanded="false">
                     <i class="fa fa-cogs"></i> <span class="caret"></span>
                 </button>
-                <div class="dropdown-menu dropdown-menu-right">
+                <ul class="dropdown-menu dropdown-menu-right" style="min-width: 150px; padding: 5px 0;">
             ';
 
             if ($this->viewPermission) {
                 $option .= '
-                    <div class="col-12" style="margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_direktur/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-info" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-file"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_direktur/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-file text-info"></i> View
                         </a>
-                        <span style="font-weight: 500"> View </span>
-                    </div>
+                    </li>
                 ';
             }
 
@@ -534,20 +529,15 @@ class Approval_spk_direktur extends Admin_Controller
 
                 if ($valid == 1) {
                     $option .= '
-                    <div class="col-12" style="margin-top: 0.5rem; margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_direktur/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-success" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-check"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_direktur/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-check text-success"></i> Approval
                         </a>
-                        <span style="font-weight: 500"> Approval </span>
-                    </div>
+                    </li>
                 ';
                 }
             }
-            $option .= '</div>';
+            $option .= '</ul>';
 
             $nm_marketing = $item->nm_sales;
 

--- a/application/modules/approval_spk_direktur/views/index.php
+++ b/application/modules/approval_spk_direktur/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Direktur.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -151,5 +178,32 @@ $ENABLE_DELETE  = has_permission('Direktur.Delete');
             paging: true
         });
     }
+</script>
+<script type="text/javascript">
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.dropdown-menu').hide();
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+        var offset = $btn.offset();
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + $btn.outerHeight() - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - $btn.outerWidth()) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>

--- a/application/modules/approval_spk_level_1/controllers/Approval_spk_level_1.php
+++ b/application/modules/approval_spk_level_1/controllers/Approval_spk_level_1.php
@@ -84,7 +84,7 @@ class Approval_spk_level_1 extends Admin_Controller
             $this->db->where('a.id', $get_penawaran->detail_informasi_awal);
             $get_marketing_informasi_awal = $this->db->get()->row();
 
-            if(!empty($get_marketing_informasi_awal)) {
+            if (!empty($get_marketing_informasi_awal)) {
                 $detail_informasi_awal = $get_marketing_informasi_awal->nm_karyawan;
             }
         } else {
@@ -165,7 +165,7 @@ class Approval_spk_level_1 extends Admin_Controller
             $this->db->where('a.id', $get_penawaran->detail_informasi_awal);
             $get_marketing_informasi_awal = $this->db->get()->row();
 
-            if(!empty($get_marketing_informasi_awal)) {
+            if (!empty($get_marketing_informasi_awal)) {
                 $detail_informasi_awal = $get_marketing_informasi_awal->nm_karyawan;
             }
         } else {
@@ -351,21 +351,16 @@ class Approval_spk_level_1 extends Admin_Controller
                     aria-expanded="false">
                     <i class="fa fa-cogs"></i> <span class="caret"></span>
                 </button>
-                <div class="dropdown-menu dropdown-menu-right">
+                <ul class="dropdown-menu dropdown-menu-right" style="min-width: 150px; padding: 5px 0;">
             ';
 
             if ($this->viewPermission) {
                 $option .= '
-                    <div class="col-12" style="margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_level_1/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-info" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-file"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_level_1/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-file text-info"></i> View
                         </a>
-                        <span style="font-weight: 500"> View </span>
-                    </div>
+                    </li>
                 ';
             }
 
@@ -387,20 +382,15 @@ class Approval_spk_level_1 extends Admin_Controller
 
                 if ($valid == 1) {
                     $option .= '
-                    <div class="col-12" style="margin-top: 0.5rem; margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_level_1/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-success" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-check"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_level_1/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-check text-success"></i> Approval
                         </a>
-                        <span style="font-weight: 500"> Approval </span>
-                    </div>
+                    </li>
                 ';
                 }
             }
-            $option .= '</div>';
+            $option .= '</ul>';
 
             $nm_marketing = $item->nm_sales;
 

--- a/application/modules/approval_spk_level_1/views/index.php
+++ b/application/modules/approval_spk_level_1/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Approval_SPK.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -150,5 +177,32 @@ $ENABLE_DELETE  = has_permission('Approval_SPK.Delete');
             paging: true
         });
     }
+</script>
+<script type="text/javascript">
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.dropdown-menu').hide();
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+        var offset = $btn.offset();
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + $btn.outerHeight() - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - $btn.outerWidth()) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>

--- a/application/modules/approval_spk_level_2/controllers/Approval_spk_level_2.php
+++ b/application/modules/approval_spk_level_2/controllers/Approval_spk_level_2.php
@@ -84,7 +84,7 @@ class Approval_spk_level_2 extends Admin_Controller
             $this->db->where('a.id', $get_penawaran->detail_informasi_awal);
             $get_marketing_informasi_awal = $this->db->get()->row();
 
-            if(!empty($get_marketing_informasi_awal)) {
+            if (!empty($get_marketing_informasi_awal)) {
                 $detail_informasi_awal = $get_marketing_informasi_awal->nm_karyawan;
             }
         } else {
@@ -116,7 +116,7 @@ class Approval_spk_level_2 extends Admin_Controller
     {
         $id_spk_penawaran = urldecode($id_spk_penawaran);
         $id_spk_penawaran = str_replace('|', '/', $id_spk_penawaran);
-        
+
         $get_spk_penawaran = $this->db->get_where('kons_tr_spk_penawaran', ['id_spk_penawaran' => $id_spk_penawaran])->row();
         $get_spk_penawaran_subcont = $this->db->get_where('kons_tr_spk_penawaran_subcont', ['id_spk_penawaran' => $id_spk_penawaran])->result();
         $get_spk_penawaran_payment = $this->db->get_where('kons_tr_spk_penawaran_payment', ['id_spk_penawaran' => $id_spk_penawaran])->result();
@@ -165,7 +165,7 @@ class Approval_spk_level_2 extends Admin_Controller
             $this->db->where('a.id', $get_penawaran->detail_informasi_awal);
             $get_marketing_informasi_awal = $this->db->get()->row();
 
-            if(!empty($get_marketing_informasi_awal)) {
+            if (!empty($get_marketing_informasi_awal)) {
                 $detail_informasi_awal = $get_marketing_informasi_awal->nm_karyawan;
             }
         } else {
@@ -243,7 +243,7 @@ class Approval_spk_level_2 extends Admin_Controller
         $this->db->order_by('a.input_date', 'desc');
 
         $get_data_all = $this->db->get();
-        
+
         // print_r($this->is_admin);
         // echo '<br><br>';
         // print_r($this->db->last_query());
@@ -290,21 +290,16 @@ class Approval_spk_level_2 extends Admin_Controller
                     aria-expanded="false">
                     <i class="fa fa-cogs"></i> <span class="caret"></span>
                 </button>
-                <div class="dropdown-menu dropdown-menu-right">
+                <ul class="dropdown-menu dropdown-menu-right" style="min-width: 150px; padding: 5px 0;">
             ';
 
             if ($this->viewPermission) {
                 $option .= '
-                    <div class="col-12" style="margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_level_2/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-info" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-file"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_level_2/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-file text-info"></i> View
                         </a>
-                        <span style="font-weight: 500"> View </span>
-                    </div>
+                    </li>
                 ';
             }
 
@@ -314,20 +309,15 @@ class Approval_spk_level_2 extends Admin_Controller
 
                 if ($valid == 1) {
                     $option .= '
-                    <div class="col-12" style="margin-top: 0.5rem; margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_level_2/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-success" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-check"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_level_2/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-check text-success"></i> Approval
                         </a>
-                        <span style="font-weight: 500"> Approval </span>
-                    </div>
+                    </li>
                 ';
                 }
             }
-            $option .= '</div>';
+            $option .= '</ul>';
 
             $nm_marketing = $item->nm_sales;
 

--- a/application/modules/approval_spk_level_2/views/index.php
+++ b/application/modules/approval_spk_level_2/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Approval_SPK.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -150,5 +177,32 @@ $ENABLE_DELETE  = has_permission('Approval_SPK.Delete');
             paging: true
         });
     }
+</script>
+<script type="text/javascript">
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.dropdown-menu').hide();
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+        var offset = $btn.offset();
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + $btn.outerHeight() - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - $btn.outerWidth()) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>

--- a/application/modules/approval_spk_manager_sales/controllers/Approval_spk_manager_sales.php
+++ b/application/modules/approval_spk_manager_sales/controllers/Approval_spk_manager_sales.php
@@ -508,21 +508,16 @@ class Approval_spk_manager_sales extends Admin_Controller
                     aria-expanded="false">
                     <i class="fa fa-cogs"></i> <span class="caret"></span>
                 </button>
-                <div class="dropdown-menu dropdown-menu-right">
+                <ul class="dropdown-menu dropdown-menu-right" style="min-width: 150px; padding: 5px 0;">
             ';
 
             if ($this->viewPermission) {
                 $option .= '
-                    <div class="col-12" style="margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_manager_sales/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-info" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-file"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_manager_sales/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-file text-info"></i> View
                         </a>
-                        <span style="font-weight: 500"> View </span>
-                    </div>
+                    </li>
                 ';
             }
 
@@ -547,20 +542,15 @@ class Approval_spk_manager_sales extends Admin_Controller
 
                 if ($valid == 1) {
                     $option .= '
-                    <div class="col-12" style="margin-top: 0.5rem; margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_manager_sales/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-success" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-check"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_manager_sales/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-check text-success"></i> Approval
                         </a>
-                        <span style="font-weight: 500"> Approval </span>
-                    </div>
+                    </li>
                 ';
                 }
             }
-            $option .= '</div>';
+            $option .= '</ul>';
 
             $nm_marketing = $item->nm_sales;
 

--- a/application/modules/approval_spk_manager_sales/views/index.php
+++ b/application/modules/approval_spk_manager_sales/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Project_Leader.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -158,5 +185,32 @@ $ENABLE_DELETE  = has_permission('Project_Leader.Delete');
             scrollX: true
         });
     }
+</script>
+<script type="text/javascript">
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.dropdown-menu').hide();
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+        var offset = $btn.offset();
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + $btn.outerHeight() - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - $btn.outerWidth()) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>

--- a/application/modules/approval_spk_penawaran/controllers/Approval_spk_penawaran.php
+++ b/application/modules/approval_spk_penawaran/controllers/Approval_spk_penawaran.php
@@ -181,39 +181,29 @@ class Approval_spk_penawaran extends Admin_Controller
                     aria-expanded="false">
                     <i class="fa fa-cogs"></i> <span class="caret"></span>
                 </button>
-                <div class="dropdown-menu dropdown-menu-right">
+                <ul class="dropdown-menu dropdown-menu-right" style="min-width: 150px; padding: 5px 0;">
             ';
 
             if ($this->viewPermission) {
                 $option .= '
-                    <div class="col-12" style="margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_penawaran/view_spk/' . $item->id_spk_penawaran) . '" class="btn btn-sm btn-info" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-file"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_penawaran/view_spk/' . $item->id_spk_penawaran) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-file text-info"></i> View
                         </a>
-                        <span style="font-weight: 500"> View </span>
-                    </div>
+                    </li>
                 ';
             }
 
             if ($this->managePermission) {
                 $option .= '
-                    <div class="col-12" style="margin-top: 0.5rem; margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_penawaran/approval_spk/' . $item->id_spk_penawaran) . '" class="btn btn-sm btn-success" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-check"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_penawaran/approval_spk/' . $item->id_spk_penawaran) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-check text-success"></i> Approval
                         </a>
-                        <span style="font-weight: 500"> Approval </span>
-                    </div>
+                    </li>
                 ';
             }
-            $option .= '</div>';
+            $option .= '</ul>';
 
             $nm_marketing = $item->nm_sales;
 
@@ -346,7 +336,8 @@ class Approval_spk_penawaran extends Admin_Controller
         ]);
     }
 
-    public function approve_spk() {
+    public function approve_spk()
+    {
         $post = $this->input->post();
 
         $id_spk_penawaran = $post['id_spk_penawaran'];

--- a/application/modules/approval_spk_penawaran/views/index.php
+++ b/application/modules/approval_spk_penawaran/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Approval_SPK.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -150,5 +177,32 @@ $ENABLE_DELETE  = has_permission('Approval_SPK.Delete');
             paging: true
         });
     }
+</script>
+<script type="text/javascript">
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.dropdown-menu').hide();
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+        var offset = $btn.offset();
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + $btn.outerHeight() - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - $btn.outerWidth()) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>

--- a/application/modules/approval_spk_project_leader/controllers/Approval_spk_project_leader.php
+++ b/application/modules/approval_spk_project_leader/controllers/Approval_spk_project_leader.php
@@ -523,21 +523,16 @@ class Approval_spk_project_leader extends Admin_Controller
                     aria-expanded="false">
                     <i class="fa fa-cogs"></i> <span class="caret"></span>
                 </button>
-                <div class="dropdown-menu dropdown-menu-right">
+                <ul class="dropdown-menu dropdown-menu-right" style="min-width: 150px; padding: 5px 0;">
             ';
 
             if ($this->viewPermission) {
                 $option .= '
-                    <div class="col-12" style="margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_project_leader/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-info" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-file"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_project_leader/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-file text-info"></i> View
                         </a>
-                        <span style="font-weight: 500"> View </span>
-                    </div>
+                    </li>
                 ';
             }
 
@@ -558,20 +553,15 @@ class Approval_spk_project_leader extends Admin_Controller
 
                 if ($valid == 1) {
                     $option .= '
-                    <div class="col-12" style="margin-top: 0.5rem; margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_project_leader/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-success" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-check"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_project_leader/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-check text-success"></i> Approval
                         </a>
-                        <span style="font-weight: 500"> Approval </span>
-                    </div>
+                    </li>
                 ';
                 }
             }
-            $option .= '</div>';
+            $option .= '</ul>';
 
             $nm_marketing = $item->nm_sales;
 

--- a/application/modules/approval_spk_project_leader/views/index.php
+++ b/application/modules/approval_spk_project_leader/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Project_Leader.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -159,5 +186,32 @@ $ENABLE_DELETE  = has_permission('Project_Leader.Delete');
             scrollX: true
         });
     }
+</script>
+<script type="text/javascript">
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.dropdown-menu').hide();
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+        var offset = $btn.offset();
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + $btn.outerHeight() - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - $btn.outerWidth()) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>

--- a/application/modules/approval_spk_sales_konsultan/controllers/Approval_spk_sales_konsultan.php
+++ b/application/modules/approval_spk_sales_konsultan/controllers/Approval_spk_sales_konsultan.php
@@ -571,21 +571,16 @@ class Approval_spk_sales_konsultan extends Admin_Controller
                     aria-expanded="false">
                     <i class="fa fa-cogs"></i> <span class="caret"></span>
                 </button>
-                <div class="dropdown-menu dropdown-menu-right">
+                <ul class="dropdown-menu dropdown-menu-right" style="min-width: 150px; padding: 5px 0;">
             ';
 
             if ($this->viewPermission) {
                 $option .= '
-                    <div class="col-12" style="margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_sales_konsultan/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-info" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-file"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_sales_konsultan/view_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-file text-info"></i> View
                         </a>
-                        <span style="font-weight: 500"> View </span>
-                    </div>
+                    </li>
                 ';
             }
 
@@ -606,20 +601,15 @@ class Approval_spk_sales_konsultan extends Admin_Controller
 
                 if ($valid == 1) {
                     $option .= '
-                    <div class="col-12" style="margin-top: 0.5rem; margin-left: 0.5rem">
-                        <a href="' . base_url('approval_spk_sales_konsultan/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" class="btn btn-sm btn-success" style="color: #000000">
-                            <div class="col-12 dropdown-item">
-                            <b>
-                                <i class="fa fa-check"></i>
-                            </b>
-                            </div>
+                    <li>
+                        <a href="' . base_url('approval_spk_sales_konsultan/approval_spk/' . urlencode(str_replace('/', '|', $item->id_spk_penawaran))) . '" style="display: block; padding: 5px 15px; color: #333; text-decoration: none;">
+                            <i class="fa fa-check text-success"></i> Approval
                         </a>
-                        <span style="font-weight: 500"> Approval </span>
-                    </div>
+                    </li>
                 ';
                 }
             }
-            $option .= '</div>';
+            $option .= '</ul>';
 
             $nm_marketing = $item->nm_sales;
 

--- a/application/modules/approval_spk_sales_konsultan/views/index.php
+++ b/application/modules/approval_spk_sales_konsultan/views/index.php
@@ -13,9 +13,36 @@ $ENABLE_DELETE  = has_permission('Sales_&_Konsultan.Delete');
     }
 
     .dropdown-menu {
-        top: 100%;
-        position: absolute;
-        overflow: auto;
+        list-style: none;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, .15);
+        border-radius: 4px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+        z-index: 99999;
+        padding: 5px 0;
+        margin: 0;
+        min-width: 150px;
+        display: none;
+    }
+
+    .dropdown-menu li a {
+        display: block;
+        padding: 5px 15px;
+        color: #333;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .dropdown-menu li a:hover {
+        background-color: #f5f5f5;
+    }
+
+    .table-responsive,
+    .dataTables_scrollBody,
+    .dataTables_wrapper,
+    .box-body,
+    .box {
+        overflow: visible !important;
     }
 </style>
 <div id="alert_edit" class="alert alert-success alert-dismissable" style="padding: 15px; display: none;"></div>
@@ -158,5 +185,32 @@ $ENABLE_DELETE  = has_permission('Sales_&_Konsultan.Delete');
             scrollX: true
         });
     }
+</script>
+<script type="text/javascript">
+    $(document).on('click', '.dropdown-toggle', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.dropdown-menu').hide();
+        var $btn = $(this);
+        var $menu = $btn.siblings('.dropdown-menu');
+        if ($menu.is(':visible')) {
+            $menu.hide();
+            return;
+        }
+        var offset = $btn.offset();
+        $menu.css({
+            position: 'fixed',
+            top: (offset.top + $btn.outerHeight() - $(window).scrollTop()) + 'px',
+            left: 'auto',
+            right: ($(window).width() - offset.left - $btn.outerWidth()) + 'px',
+            display: 'block',
+            zIndex: 99999
+        });
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.btn-group').length) {
+            $('.dropdown-menu').hide();
+        }
+    });
 </script>
 <script src="<?= base_url('assets/js/basic.js') ?>"></script>


### PR DESCRIPTION
Standardize dropdown styles and behavior across many approval views: replace absolute dropdown markup with ul/li anchor structure, add consistent CSS (background, borders, padding, min-width) and JS to position menus fixed to avoid being clipped inside DataTables/scroll containers and close on outside click. Convert various controller action blocks to use the new menu markup. In Approval_penawaran controller: use HR database connection to fetch marketing name, add customer/package selects to main query, and tighten search handling. Misc: small whitespace/formatting fixes and a minor method signature/style adjustment in Approval_spk_penawaran.